### PR TITLE
add color match & rm ugly shadow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/node_modules
 *.log

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Color = require('color');
 exports.decorateConfig = (config) => {
     const backColor = Color(config.backgroundColor)
     const colors = {
-        light: backColor.lighten(0.5).string(),
+        light: backColor.lightness(26).string(),
         dark: backColor.darken(0.18).string()
     }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 'use strict'
+const Color = require('color');
 
 exports.decorateConfig = (config) => {
+    const backColor = Color(config.backgroundColor);
+    const colors = {
+        light: backColor.lighten(0.5).string(),
+        dark: backColor.darken(0.18).string(),
+    }
+
     return Object.assign({}, config, {
         termCSS: `
             ${config.termCSS || ''}
@@ -16,12 +23,15 @@ exports.decorateConfig = (config) => {
                 width: 4px;
                 height: 4px;
             }
+            ::-webkit-scrollbar-track, ::-webkit-scrollbar-thumb {
+                -webkit-border-radius: 8px;
+            }
             ::-webkit-scrollbar-track {
-                background-color: rgba(32,36,42,1);
+                background-color: ${colors.dark};
             }
             ::-webkit-scrollbar-thumb {
-                background-color: rgba(60,66,77,1);
-                -webkit-border-radius: 8px;
+                background-color: ${colors.light};
+                -webkit-box-shadow: none;
             }
         `
     })

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 const Color = require('color');
 
 exports.decorateConfig = (config) => {
+    const backColor = Color(config.backgroundColor)
     const colors = {
-        light: Color(config.foregroundColor).darken(0.62).string(),
-        dark: Color(config.backgroundColor).darken(0.2).string(),
+        light: backColor.lighten(0.5).string(),
+        dark: backColor.darken(0.18).string()
     }
 
     return Object.assign({}, config, {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,9 @@
 const Color = require('color');
 
 exports.decorateConfig = (config) => {
-    const backColor = Color(config.backgroundColor);
     const colors = {
-        light: backColor.lighten(0.5).string(),
-        dark: backColor.darken(0.18).string(),
+        light: Color(config.foregroundColor).darken(0.62).string(),
+        dark: Color(config.backgroundColor).darken(0.2).string(),
     }
 
     return Object.assign({}, config, {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const Color = require('color');
 exports.decorateConfig = (config) => {
     const backColor = Color(config.backgroundColor)
     const colors = {
-        light: backColor.lightness(26).string(),
+        light: backColor.lightness(27).string(),
         dark: backColor.darken(0.18).string()
     }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "scroll",
     "scrollbar"
   ],
+  "dependencies": {
+    "color": "^1.0.3"
+  },
   "author": "Morten Sørensen <morten@moso.io>",
   "license": "MIT"
 }


### PR DESCRIPTION
Matches color from active theme instead so that it works with other themes out of the box. Rounded borders on both track & thumb.

Additionally removed the ugly blue default box shadow that you seem to have forgot about ✌️

`hyper-dark-scrollbar` with my theme `hyper-chesterish` below
![skarmavbild 2017-01-18 kl 03 05 10](https://cloud.githubusercontent.com/assets/1430576/22048102/2c032894-dd2b-11e6-8933-d5c9a72f9182.png)
